### PR TITLE
Fixed small typo in code

### DIFF
--- a/theonionbox/theonionbox.py
+++ b/theonionbox/theonionbox.py
@@ -95,7 +95,7 @@ def main(ctx, debug, trace, config, cc, log):
     pass
 
 
-@main.resultcallback()
+@main.result_callback()
 def launcher(results, debug, trace, config, cc, log):
 
     # This raises (by intension) if no context.


### PR DESCRIPTION
decorator resultcallback doesn't exists so I changed it to result_callback

same issue is present also in origin/devel20.3, I wasn't sure to which branch do you prefer PR